### PR TITLE
Agregar metodo de instalacion con apmpkg [adi]

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@
 
 ```
 
+## Apmpkg
+De igual manera lo puedes instalar con [apmpkg](https://github.com/kedap/apmpkg) con el siguiente comando:
+
+```sh
+
+    apmpkg instalar -u https://raw.githubusercontent.com/Kedap/beef-for-cerberus/main/beef-for-cerberus.adi
+```
+
 <hr>
 
 # Previews:

--- a/beef-cerberus.sh
+++ b/beef-cerberus.sh
@@ -5,8 +5,9 @@ if [ $? -eq 1 ]; then
     echo "Al parecer no has configurado tu authtoken, Porque no lo hacemos?"
     echo "Ingresa tu authtoken, para mas informacion en https://dashboard.ngrok.com/auth/your-authtoken"
     read token
+    cp /opt/beef-for-cerberus/depen/config.yml /tmp/config.yml
     echo -e "authtoken: $token" > /opt/beef-for-cerberus/depen/config.yml
-    cat /opt/beef-for-cerberus/depen/config.yml >> depen/cerberus.yml 
+    cat /tmp/config.yml >> depen/cerberus.yml 
 fi
 
 pushd /opt/beef-for-cerberus > /dev/null

--- a/beef-cerberus.sh
+++ b/beef-cerberus.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cat /opt/beef-for-cerberus/depen/config.yml | grep authtoken > /dev/null 2>&1
+if [ $? -eq 1 ]; then
+    echo "Al parecer no has configurado tu authtoken, Porque no lo hacemos?"
+    echo "Ingresa tu authtoken, para mas informacion en https://dashboard.ngrok.com/auth/your-authtoken"
+    read token
+    echo -e "authtoken: $token" > /opt/beef-for-cerberus/depen/config.yml
+    cat /opt/beef-for-cerberus/depen/config.yml >> depen/cerberus.yml 
+fi
+
+pushd /opt/beef-for-cerberus > /dev/null
+python3 cerberus.py $@
+popd > /dev/null

--- a/beef-for-cerberus.adi
+++ b/beef-for-cerberus.adi
@@ -7,6 +7,7 @@ descrip = "Herramienta para automatizar BeEF fuera de LAN!"
 pagina = "https://github.com/tony23x/beef-for-cerberus"
 licensia = "Desconocida"
 dependencias = ["curl", "wget", "php", "openssh", "net-tools", "python3", "unzip", "ngrok"]
+cmd_depen = ["curl", "wget", "php", "ssh", "iptunnel", "python3", "unzip", "ngrok"]
 abi_dependencias = ["ngrok"]
 conflicto = "/usr/bin/cerberus.py"
 

--- a/beef-for-cerberus.adi
+++ b/beef-for-cerberus.adi
@@ -1,0 +1,35 @@
+[paquete]
+
+nombre = "beef-cerberus"
+version = "4.0"
+rama = "estable"
+descrip = "Herramienta para automatizar BeEF fuera de LAN!"
+pagina = "https://github.com/tony23x/beef-for-cerberus"
+licensia = "Desconocida"
+dependencias = ["curl", "wget", "php", "openssh", "net-tools", "python3", "unzip", "ngrok"]
+abi_dependencias = ["ngrok"]
+conflicto = "/usr/bin/cerberus.py"
+
+[dependencias_adi]
+ngrok = "https://krep0.bitbucket.io/apmpkg/ngrok-2.3.40.abi.tar.gz"
+
+[pip]
+
+version = 3
+requirements = true
+file = "requirements.txt"
+
+[descarga]
+
+#git = "https://github.com/tony23x/beef-for-cerberus.git"
+#Para testeo
+git = "https://github.com/kedap/beef-for-cerberus.git"
+carpeta = "beef-for-cerberus"
+sha256sum = "SALTAR"
+
+[instalacion]
+
+opt_src = true
+files = ["beef-cerberus.sh"]
+ruta = ["/usr/bin/beef-cerberus"]
+mensaje = "Ejecuta 'beef-cerberus' para iniciar :)"


### PR DESCRIPTION
Solo se debe de modificar [la linea de source de apmpkg](https://github.com/Kedap/beef-for-cerberus/blob/main/beef-for-cerberus.adi#L25) y [modificar el README](https://github.com/Kedap/beef-for-cerberus#apmpkg) Para que la instalacion apunte a el repositorio original


Edit: La instalacion sera posible cuando salga la version 1.2 de apmpkg que se encuentra en desarrollo actualmente porque no es compatible con la version actual